### PR TITLE
Fix hardware decoding

### DIFF
--- a/src/mpv/video/decode/vd_lavc.c
+++ b/src/mpv/video/decode/vd_lavc.c
@@ -115,12 +115,12 @@ const struct m_sub_options vd_lavc_conf = {
     },
 };
 
-const struct vd_lavc_hwdec mp_vd_lavc_vdpau;
-const struct vd_lavc_hwdec mp_vd_lavc_vda;
-const struct vd_lavc_hwdec mp_vd_lavc_vaapi;
-const struct vd_lavc_hwdec mp_vd_lavc_vaapi_copy;
-const struct vd_lavc_hwdec mp_vd_lavc_dxva2_copy;
-const struct vd_lavc_hwdec mp_vd_lavc_rpi;
+extern const struct vd_lavc_hwdec mp_vd_lavc_vdpau;
+extern const struct vd_lavc_hwdec mp_vd_lavc_vda;
+extern const struct vd_lavc_hwdec mp_vd_lavc_vaapi;
+extern const struct vd_lavc_hwdec mp_vd_lavc_vaapi_copy;
+extern const struct vd_lavc_hwdec mp_vd_lavc_dxva2_copy;
+extern const struct vd_lavc_hwdec mp_vd_lavc_rpi;
 
 static const struct vd_lavc_hwdec *const hwdec_list[] = {
 #if HAVE_RPI


### PR DESCRIPTION
The definitions of mp_vd_lavc_* variables are in video/decode/*.c files respectively.
This resolves a regression where only software decoding is possible
with the error message "Requested hardware decoder not compiled."